### PR TITLE
feat: apply retro header styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <title>Labeon – Zebra Printer Utility for macOS</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
     <style>
         body {
             background-color: #252525;
@@ -16,10 +17,13 @@
         header {
             padding: 3rem 1rem 1.5rem 1rem;
             text-align: center;
+            background: linear-gradient(to right, orange, red);
+            color: #fff;
         }
         h1 {
             margin: 0;
             font-size: 3rem;
+            font-family: 'Orbitron', sans-serif;
         }
         p {
             font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- load Orbitron from Google Fonts for a retro feel
- style the header with an orange-to-red gradient background and use the Orbitron font

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eef548640832e80f5a1b692a4bcd5