### PR TITLE
style: replicate label.live layout with placeholder content

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,135 +1,147 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>Labeon – Zebra Printer Utility for macOS</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
-    <style>
-        body {
-            background-color: #252525;
-            color: #ededed;
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-        }
-        header {
-            padding: 3rem 1rem 1.5rem 1rem;
-            text-align: center;
-            background: linear-gradient(to right, orange, red);
-            color: #fff;
-        }
-        h1 {
-            margin: 0;
-            font-size: 3rem;
-            font-family: 'Orbitron', sans-serif;
-        }
-        p {
-            font-size: 1.2rem;
-            max-width: 700px;
-            margin: 1rem auto;
-            line-height: 1.6;
-        }
-        .pricing {
-            display: flex;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 2rem;
-            padding: 2rem 1rem;
-        }
-        .plan {
-            background-color: #333;
-            border: 1px solid #444;
-            padding: 2rem;
-            border-radius: 10px;
-            max-width: 300px;
-            text-align: center;
-        }
-        .plan h2 {
-            margin-top: 0;
-            font-size: 1.6rem;
-        }
-        .plan p {
-            font-size: 1rem;
-        }
-        .btn {
-            display: inline-block;
-            padding: 0.75rem 1.5rem;
-            margin-top: 1.5rem;
-            font-size: 1rem;
-            background-color: #00c9a7;
-            color: #fff;
-            border: none;
-            border-radius: 6px;
-            text-decoration: none;
-        }
-        .newsletter {
-            text-align: center;
-            padding: 2rem 1rem;
-        }
-        .newsletter form {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 1rem;
-            max-width: 400px;
-            margin: 0 auto;
-        }
-        .newsletter input[type="email"] {
-            padding: 0.5rem;
-            border-radius: 6px;
-            border: 1px solid #444;
-            background-color: #222;
-            color: #fff;
-            width: 100%;
-        }
-        footer {
-            text-align: center;
-            padding: 2rem 1rem;
-            font-size: 0.9rem;
-            color: #999;
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <title>Labeon – Placeholder Site</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <style>
+    body {
+      margin: 0;
+      font-family: 'Inter', sans-serif;
+      color: #333;
+    }
+    nav {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1rem 2rem;
+      background: #fff;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    }
+    nav .menu {
+      list-style: none;
+      display: flex;
+      gap: 1.5rem;
+      margin: 0;
+      padding: 0;
+    }
+    nav a {
+      text-decoration: none;
+      color: #333;
+      font-weight: 500;
+    }
+    .hero {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      padding: 4rem 2rem;
+      background: #f5f5f5;
+    }
+    .hero-text {
+      max-width: 500px;
+    }
+    .hero-text h1 {
+      font-size: 2.5rem;
+      margin: 0 0 1rem 0;
+    }
+    .hero-text p {
+      font-size: 1.2rem;
+      line-height: 1.6;
+    }
+    .btn {
+      display: inline-block;
+      margin-top: 1.5rem;
+      padding: 0.75rem 1.5rem;
+      background: #007bff;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+    .features {
+      text-align: center;
+      padding: 4rem 2rem;
+    }
+    .feature-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+      justify-content: center;
+      margin-top: 2rem;
+    }
+    .feature {
+      max-width: 300px;
+      text-align: center;
+    }
+    .feature img {
+      width: 80px;
+      height: 80px;
+    }
+    .cta {
+      text-align: center;
+      padding: 4rem 2rem;
+      background: #333;
+      color: #fff;
+    }
+    footer {
+      text-align: center;
+      padding: 2rem 1rem;
+      font-size: 0.9rem;
+      color: #666;
+    }
+  </style>
 </head>
 <body>
-    <header>
-        <h1>Labeon</h1>
-        <p>A modern macOS utility for configuring Zebra printers over USB, Wi-Fi, and Ethernet.<br>
-        Design labels, send ZPL, and manage printer settings — no drivers or Windows required.</p>
-    </header>
+  <nav>
+    <div class="logo">Labeon</div>
+    <ul class="menu">
+      <li><a href="#features">Features</a></li>
+      <li><a href="#download">Download</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ul>
+  </nav>
 
-    <section class="pricing">
-        <div class="plan">
-            <h2>Free</h2>
-            <p>✔ USB configuration<br>✔ 1 printer<br>✔ Label preview</p>
-            <a class="btn" href="#">Download</a>
-        </div>
-        <div class="plan">
-            <h2>Pro</h2>
-            <p>✔ Everything in Free<br>✔ Wi-Fi & Ethernet setup<br>✔ Command tester<br>✔ Multiple printers</p>
-            <a class="btn" href="https://buy.stripe.com/test_fZebIrgU5aLg6yQ7ss">Subscribe – $9.99/mo</a>
-        </div>
-        <div class="plan">
-            <h2>Lifetime</h2>
-            <p>✔ Everything in Pro<br>✔ One-time payment<br>✔ Priority support</p>
-            <a class="btn" href="https://buy.stripe.com/test_bIYbJle8z4TIdck8ww">Buy – $149</a>
-        </div>
-    </section>
+  <section class="hero">
+    <div class="hero-text">
+      <h1>Placeholder Headline</h1>
+      <p>Replace this text with a compelling description of the product. This section mirrors the layout of label.live but uses placeholder content.</p>
+      <a href="#" class="btn">Download</a>
+    </div>
+    <div class="hero-image">
+      <img src="https://via.placeholder.com/500x300" alt="Screenshot placeholder">
+    </div>
+  </section>
 
-    <section class="newsletter">
-        <h2>Join the beta</h2>
-        <form action="https://example.us1.list-manage.com/subscribe/post?u=YOUR_U_VALUE&amp;id=YOUR_ID_VALUE" method="post" target="_blank" novalidate>
-            <input type="email" name="EMAIL" placeholder="Email address" required>
-            <div style="position: absolute; left: -5000px;" aria-hidden="true">
-                <input type="text" name="b_YOUR_U_VALUE_YOUR_ID_VALUE" tabindex="-1" value="">
-            </div>
-            <button class="btn" type="submit">Notify me</button>
-        </form>
-    </section>
+  <section id="features" class="features">
+    <h2>Features</h2>
+    <div class="feature-grid">
+      <div class="feature">
+        <img src="https://via.placeholder.com/80" alt="Feature 1">
+        <h3>Feature One</h3>
+        <p>Short description of the first feature. Replace with real text later.</p>
+      </div>
+      <div class="feature">
+        <img src="https://via.placeholder.com/80" alt="Feature 2">
+        <h3>Feature Two</h3>
+        <p>Short description of the second feature. Replace with real text later.</p>
+      </div>
+      <div class="feature">
+        <img src="https://via.placeholder.com/80" alt="Feature 3">
+        <h3>Feature Three</h3>
+        <p>Short description of the third feature. Replace with real text later.</p>
+      </div>
+    </div>
+  </section>
 
-    <footer>
-        <p>Labeon is an independent product and is not affiliated with Zebra Technologies. © 2025 Labeon</p>
-    </footer>
+  <section class="cta" id="download">
+    <h2>Ready to try it?</h2>
+    <a href="#" class="btn">Get Started</a>
+  </section>
+
+  <footer>
+    <p>© 2025 Labeon. Placeholder footer text.</p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign index.html to mimic label.live layout using placeholder text and images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ef65ddb2c832e9887a87af7b5a8a3