### PR TITLE
style: use retro Orbitron font for header logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <title>Labeon – Placeholder Site</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <style>
     body {
       margin: 0;
@@ -30,6 +31,9 @@
       text-decoration: none;
       color: #333;
       font-weight: 500;
+    }
+    .logo {
+      font-family: 'Orbitron', sans-serif;
     }
     .hero {
       display: flex;


### PR DESCRIPTION
## Summary
- load Orbitron Google Font
- apply Orbitron font to header logo for retro styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688efa4f5170832ebd65424fcebee99a